### PR TITLE
chore: Bump sigstore/gh-action-sigstore-python action to v3.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,8 +74,9 @@ jobs:
         path: dist/
 
     - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v1.2.3
+      uses: sigstore/gh-action-sigstore-python@v3.0.0
       with:
+        release-signing-artifacts: false
         inputs: >-
           ./dist/*.tar.gz
           ./dist/*.whl


### PR DESCRIPTION
Bump `gh-action-sigstore-python` action to `v3.0.0` which transitively also updates the `upload-artifact` versions bumped in https://github.com/gr4vy/gr4vy-python/pull/45

See release notes: https://github.com/sigstore/gh-action-sigstore-python/releases

Note that release was done to pypi (https://pypi.org/project/gr4vy/) but we're missing the github release (https://github.com/gr4vy/gr4vy-python/releases)