### PR TITLE
test: cover API key pairs and refund settlements endpoints

### DIFF
--- a/tests/backoffice/test_api_key_pairs.py
+++ b/tests/backoffice/test_api_key_pairs.py
@@ -1,0 +1,46 @@
+"""API key pairs: list is a happy path; create/get/update/delete are reached at
+the request level. Creating a key pair requires a real, existing role whose
+scopes are a subset of the caller's — the mock env has no such role to assign, so
+create is rejected with a 4xx (endpoint still reached), and get/update/delete
+target a MISSING_ID that returns a 4xx as well."""
+
+from utils import MISSING_ID, reach
+from utils.environment import create_client
+
+
+def test_list_is_happy_path(merchant):
+    # API key pairs are an account-level resource (a pair can span every merchant
+    # account), so drive them with an unscoped (admin) client, like
+    # merchant_accounts — not the merchant-scoped merchant.client.
+    sdk = create_client(merchant.private_key)
+    listed = sdk.api_key_pairs.list()
+    assert listed is not None
+
+
+def test_create_get_update_delete_are_reached(merchant):
+    sdk = create_client(merchant.private_key)
+
+    # create needs a valid role_id whose scopes are a subset of the caller's;
+    # MISSING_ID is not a real role, so the API rejects it with a 4xx. The
+    # endpoint is still reached.
+    reach.reaches(
+        lambda: sdk.api_key_pairs.create(
+            display_name="e2e-test-key-pair",
+            role_ids=[MISSING_ID],
+        ),
+        "api_key_pairs.create",
+    )
+    reach.reaches(
+        lambda: sdk.api_key_pairs.get(api_key_pair_id=MISSING_ID),
+        "api_key_pairs.get",
+    )
+    reach.reaches(
+        lambda: sdk.api_key_pairs.update(
+            api_key_pair_id=MISSING_ID, display_name="renamed"
+        ),
+        "api_key_pairs.update",
+    )
+    reach.reaches(
+        lambda: sdk.api_key_pairs.delete(api_key_pair_id=MISSING_ID),
+        "api_key_pairs.delete",
+    )

--- a/tests/processing/test_transactions.py
+++ b/tests/processing/test_transactions.py
@@ -1,5 +1,5 @@
 """Transactions resource: create/get/list/update plus the read sub-resources
-(actions, events, settlements) and the cancel action. Capture / void / refund /
+(actions, events, settlements, refund settlements) and the cancel action. Capture / void / refund /
 sync are covered as a story in flows/test_transaction_lifecycle.py."""
 
 from utils import MISSING_ID, checkout_fields, fixtures, reach
@@ -51,6 +51,19 @@ def test_read_subresources(merchant):
             transaction_id=txn.id, settlement_id=MISSING_ID
         ),
         "transactions.settlements.get",
+    )
+
+    refund_settlements = sdk.transactions.refund_settlements.list(
+        transaction_id=txn.id
+    )
+    assert refund_settlements is not None
+
+    # A specific refund settlement needs a settled transaction we cannot force here.
+    reach.reaches(
+        lambda: sdk.transactions.refund_settlements.get(
+            transaction_id=txn.id, settlement_id=MISSING_ID
+        ),
+        "transactions.refund_settlements.get",
     )
 
 


### PR DESCRIPTION
## Coverage gap

CI's endpoint-coverage check counts an endpoint as covered only when a real HTTP request reaches the server. This PR closes the remaining gaps.

### API key pairs (`src/gr4vy/api_key_pairs.py`)
The generated resource exposes `list`, `create`, `get`, `update`, and `delete`, but no test exercised any of them.

New file `tests/backoffice/test_api_key_pairs.py`, mirroring the payouts / merchant-accounts conventions:
- **`list` → happy path.** Asserts the response is not `None`.
- **`create` / `get` / `update` / `delete` → reached** via `reach.reaches(...)`. Each sends a real request the API rejects with a 4xx (endpoint still reached): `create` cannot supply a valid `role_id` in the mock env, and `get`/`update`/`delete` target a `MISSING_ID`.

API key pairs are an account-level resource (a pair can span every merchant account), so the tests use an unscoped admin client via `create_client(merchant.private_key)`, matching `test_merchant_accounts.py`.

### Transaction refund settlements (`src/gr4vy/transactions_refund_settlements.py`)
The `sdk.transactions.refund_settlements` sub-resource (`list` + `get`) was uncovered.

`tests/processing/test_transactions.py::test_read_subresources` extended to mirror the existing `settlements` coverage exactly:
- **`refund_settlements.list(transaction_id=...)` → happy path.**
- **`refund_settlements.get(transaction_id=..., settlement_id=MISSING_ID)` → reached** via `reach.reaches(...)`; a specific refund settlement needs a settled transaction we cannot force in the mock env.